### PR TITLE
Add ThreadUtil

### DIFF
--- a/src/main/java/com/projectkorra/core/util/ThreadUtil.java
+++ b/src/main/java/com/projectkorra/core/util/ThreadUtil.java
@@ -1,0 +1,423 @@
+package com.projectkorra.core.util;
+
+import org.apache.commons.lang.Validate;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import com.projectkorra.core.ProjectKorra;
+
+/**
+* A utility class to provide simple and uniform ways to schedule {@link java.lang.Runnable Runnables} and {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnables}.
+*/
+public class ThreadUtil {
+	private static final ProjectKorra PLUGIN = JavaPlugin.getPlugin(ProjectKorra.class);
+
+	private ThreadUtil() {}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>synchronously</b> starting on next tick. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTask BukkitRunnable#runTask()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runTask(BukkitRunnable runnable) throws NullPointerException, IllegalStateException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		return runnable.runTask(PLUGIN);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>synchronously</b> starting on next tick. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTask BukkitScheduler#runTask()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runTask(Runnable runnable) throws NullPointerException, IllegalStateException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		return PLUGIN.getServer().getScheduler().runTask(PLUGIN, runnable);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>asynchronously</b> starting on next tick. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskAsynchronously BukkitRunnable#runTaskAsynchronously()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runTaskAsynchronously(BukkitRunnable runnable) throws NullPointerException, IllegalStateException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		return runnable.runTaskAsynchronously(PLUGIN);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>asynchronously</b> starting on next tick. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskAsynchronously BukkitScheduler#runTaskAsynchronously()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runTaskAsynchronously(Runnable runnable) throws NullPointerException, IllegalStateException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		return PLUGIN.getServer().getScheduler().runTaskAsynchronously(PLUGIN, runnable);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>synchronously</b> after the given tick delay elapses. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskLater BukkitRunnable#runTaskLater()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runDelayedTask(BukkitRunnable runnable, long delay) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		return runnable.runTaskLater(PLUGIN, delay);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>synchronously</b> after the given tick delay elapses. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskLater BukkitScheduler#runTaskLater()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link java.lang.Runnable Runnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runDelayedTask(Runnable runnable, long delay) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		return PLUGIN.getServer().getScheduler().runTaskLater(PLUGIN, runnable, delay);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>asynchronously</b> after the given tick delay elapses. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskLaterAsynchronously BukkitRunnable#runTaskLaterAsynchronously()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runDelayedTaskAsynchronously(BukkitRunnable runnable, long delay) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		return runnable.runTaskLaterAsynchronously(PLUGIN, delay);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>asynchronously</b> after the given tick delay elapses. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskLaterAsynchronously BukkitScheduler#runTaskLaterAsynchronously()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link java.lang.Runnable Runnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runDelayedTaskAsynchronously(Runnable runnable, long delay) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		return PLUGIN.getServer().getScheduler().runTaskLaterAsynchronously(PLUGIN, runnable, delay);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>synchronously</b> every tick until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskTimer BukkitRunnable#runTaskTimer()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTask(BukkitRunnable runnable) throws NullPointerException, IllegalStateException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		return runRepeatingTask(runnable, 0L, 0L);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>synchronously</b> every tick until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskTimer BukkitScheduler#runTaskTimer()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTask(Runnable runnable) throws NullPointerException, IllegalStateException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		return runRepeatingTask(runnable, 0L, 0L);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>synchronously</b> after the given tick delay elapses and then again repeatedly each tick until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskTimer BukkitRunnable#runTaskTimer()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTask(BukkitRunnable runnable, long delay) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		return runRepeatingTask(runnable, delay, 0L);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>synchronously</b> after the given tick delay elapses and then again repeatedly each tick until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskTimer BukkitScheduler#runTaskTimer()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link java.lang.Runnable Runnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTask(Runnable runnable, long delay) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		return runRepeatingTask(runnable, delay, 0L);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>synchronously</b> after the given tick delay elapses and then again repeatedly after the given period elapses until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskTimer BukkitRunnable#runTaskTimer()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable}.
+	* @param period The number of <u>ticks</u> the scheduler should wait before each subsequent execution of the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative or if the given period is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTask(BukkitRunnable runnable, long delay, long period) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		Validate.isTrue(period >= 0, "period cannot be negative");
+		return runnable.runTaskTimer(PLUGIN, delay, period);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>synchronously</b> after the given tick delay elapses and then again repeatedly after the given period elapses until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskTimer BukkitScheduler#runTaskTimer()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link java.lang.Runnable Runnable}.
+	* @param period The number of <u>ticks</u> the scheduler should wait before each subsequent execution of the given {@link java.lang.Runnable Runnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative or if the given period is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTask(Runnable runnable, long delay, long period) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		Validate.isTrue(period >= 0, "period cannot be negative");
+		return PLUGIN.getServer().getScheduler().runTaskTimer(PLUGIN, runnable, delay, period);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>asynchronously</b> every tick until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskTimerAsynchronously BukkitRunnable#runTaskTimerAsynchronously​()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTaskAsynchronously(BukkitRunnable runnable) throws NullPointerException, IllegalStateException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		return runRepeatingTaskAsynchronously(runnable, 0L, 0L);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>asynchronously</b> every tick until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskTimerAsynchronously BukkitScheduler#runTaskTimerAsynchronously​()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTaskAsynchronously(Runnable runnable) throws NullPointerException, IllegalStateException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		return runRepeatingTaskAsynchronously(runnable, 0L, 0L);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>asynchronously</b> after the given tick delay elapses and then again repeatedly each tick until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskTimerAsynchronously BukkitRunnable#runTaskTimerAsynchronously​()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTaskAsynchronously(BukkitRunnable runnable, long delay) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		return runRepeatingTaskAsynchronously(runnable, delay, 0L);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>asynchronously</b> after the given tick delay elapses and then again repeatedly each tick until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskTimerAsynchronously BukkitScheduler#runTaskTimerAsynchronously​()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link java.lang.Runnable Runnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTaskAsynchronously(Runnable runnable, long delay) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		return runRepeatingTaskAsynchronously(runnable, delay, 0L);
+	}
+
+	/**
+	* Schedules the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} to run <b>asynchronously</b> after the given tick delay elapses and then again repeatedly after the given period elapses until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitRunnable#runTaskTimerAsynchronously BukkitRunnable#runTaskTimerAsynchronously​()}.
+	*
+	* @param runnable The {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable}.
+	* @param period The number of <u>ticks</u> the scheduler should wait before each subsequent execution of the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} is null.
+	* @throws IllegalStateException if the given {@link org.bukkit.scheduler.BukkitRunnable BukkitRunnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative or if the given period is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTaskAsynchronously(BukkitRunnable runnable, long delay, long period) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		Validate.isTrue(period >= 0, "period cannot be negative");
+		return runnable.runTaskTimerAsynchronously(PLUGIN, delay, period);
+	}
+
+	/**
+	* Schedules the given {@link java.lang.Runnable Runnable} to run <b>asynchronously</b> after the given tick delay elapses and then again repeatedly after the given period elapses until manually cancelled. Wraps {@link org.bukkit.scheduler.BukkitScheduler#runTaskTimerAsynchronously BukkitScheduler#runTaskTimerAsynchronously​()}.
+	*
+	* @param runnable The {@link java.lang.Runnable Runnable} being scheduled.
+	* @param delay The number of <u>ticks</u> the scheduler should wait before beginning execution of the given {@link java.lang.Runnable Runnable}.
+	* @param period The number of <u>ticks</u> the scheduler should wait before each subsequent execution of the given {@link java.lang.Runnable Runnable}.
+	*
+	* @return A {@link org.bukkit.scheduler.BukkitTask BukkitTask} representing the given {@link java.lang.Runnable Runnable} being executed by the scheduler.
+	*
+	* @throws NullPointerException if the given {@link java.lang.Runnable Runnable} is null.
+	* @throws IllegalStateException if the given {@link java.lang.Runnable Runnable} has already been scheduled.
+	* @throws IllegalArgumentException if the given delay is negative or if the given period is negative.
+	*
+	* @version 1.0.0
+	* @since 0.0.1
+	*/
+	public static BukkitTask runRepeatingTaskAsynchronously(Runnable runnable, long delay, long period) throws NullPointerException, IllegalStateException, IllegalArgumentException {
+		Validate.notNull(runnable, "runnable cannot be null");
+		Validate.isTrue(delay >= 0, "delay cannot be negative");
+		Validate.isTrue(period >= 0, "period cannot be negative");
+		return PLUGIN.getServer().getScheduler().runTaskTimerAsynchronously(PLUGIN, runnable, delay, period);
+	}
+}


### PR DESCRIPTION
## Changes

### :heavy_check_mark: Additions 
* Adds `ThreadUtil` to assist in the scheduling and sync/async execution of `Runnable` objects and `BukkitRunnable` objects. All methods return a `BukkitTask` to allow programmatic access to the executing `BukkitRunnable` or `Runnable`.
  * `BukkitTask runTask(Runnable runnable)`
    - Schedules a `BukkitRunnable` or `Runnable` to execute.
  * `BukkitTask runTaskAsynchronously(Runnable runnable)`
    - Schedules a `BukkitRunnable` or `Runnable` to execute asynchronously.
  * `BukkitTask runDelayedTask(Runnable runnable, long delay)`
    - Schedules a `BukkitRunnable` or `Runnable` to execute after the delay
  * `BukkitTask runDelayedTaskAsynchronously(Runnable runnable, long delay)`
    - Schedules a `BukkitRunnable` or `Runnable` to execute after the delay asynchronously.
  * `BukkitTask runRepeatingTask(Runnable runnable, long delay, long period)`
    - Schedules a repeating `BukkitRunnable` or `Runnable` to execute.
    - `delay` and `period` are optional.
  * `BukkitTask runRepeatingTaskAsynchronously(Runnable runnable, long delay, long period)`
    - Schedules a repeating `BukkitRunnable` or `Runnable` to execute asynchronously.
    - `delay` and `period` are optional.

  Note: Alternative methods exist for `BukkitRunnable` and `Runnable`.

Example usage:
```java
ThreadUtil.runTask(new BukkitRunnable() {
    @Override
    public void run() {
        System.out.println("This is using a BukkitRunnable!");
    }
});
```
```java
ThreadUtil.runTask(() -> {
    System.out.println("This is using a Runnable!");
});
```

## Checklist
- [X] I have tested my changes to the best of my abilities.
- [X] I have linked to any related GitHub Issues or Trello cards.
- [X] I have made sure my code is clean, well documented, and matches the pre-existing style of the codebase.
- [x] I understand that my pull request will only be merged after it is reviewed by maintainers and any requested changes are made.
