### PR TITLE
Fix javadoc issue in ParticleUtil and seal class

### DIFF
--- a/src/main/java/com/projectkorra/core/util/ParticleUtil.java
+++ b/src/main/java/com/projectkorra/core/util/ParticleUtil.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 public class ParticleUtil {
+	private ParticleUtil() {}
 
 	/**
 	 * Spawn a single particle at the given location
@@ -96,7 +97,6 @@ public class ParticleUtil {
 	 * Spawn a single BLOCK_CRACK particle with the given BlockData at the given Location
 	 * @param block BlockData for the BLOCK_CRACK particle to show
 	 * @param loc where to spawn the particle
-	 * @param amount how many of the particle to spawn
 	 */
 	public static void spawnBlockCrack(BlockData block, Location loc) {
 		spawnBlockCrack(block, loc, 1, 0, 0, 0);


### PR DESCRIPTION
## Changes
### :wrench: Fixes 
* Fixes javadoc compilation error in `ParticleUtil`.
  * `@param amount` was added to a method without an `amount` parameter.

### :file_folder: Miscellaneous Changes
* Adds a private constructor to `ParticleUtil` to seal the class.

## Checklist
- [X] I have tested my changes to the best of my abilities.
- [X] I have linked to any related GitHub Issues or Trello cards.
- [X] I have made sure my code is clean, well documented, and matches the pre-existing style of the codebase.
- [X] I understand that my pull request will only be merged after it is reviewed by maintainers and any requested changes are made.
